### PR TITLE
Fixes regarding the newer versions of motor and object mappings

### DIFF
--- a/motorengine/aggregation/base.py
+++ b/motorengine/aggregation/base.py
@@ -159,7 +159,7 @@ class Aggregation(object):
     @return_future
     def fetch(self, callback=None, alias=None):
         coll = self.queryset.coll(alias)
-        coll.aggregate(self.to_query(), callback=self.handle_aggregation(callback))
+        coll.aggregate(self.to_query(), callback=self.handle_aggregation(callback), cursor=False)
 
     @classmethod
     def avg(cls, field, alias=None):

--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -69,12 +69,14 @@ class BaseDocument(object):
     @classmethod
     def from_son(cls, dic, _is_partly_loaded=False, _reference_loaded_fields=None):
         field_values = {}
+        _object_id = dic.pop('_id', None)
         for name, value in dic.items():
             field = cls.get_field_by_db_name(name)
             if field:
                 field_values[field.name] = field.from_son(value)
             else:
                 field_values[name] = value
+        field_values["_id"] = _object_id
 
         return cls(
             _is_partly_loaded=_is_partly_loaded,


### PR DESCRIPTION
Supressing the cursor matches the correct return value.
This is a fix when using motor 0.6.2

When objects contain an id field, the value might be overridden by the dynamic field mapping for _id.
